### PR TITLE
Add monthNameFormat parameter to customize month display in CalendarHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ fun SimpleComposeCalendar(
     indicatorLayout: CalendarDefaults.IndicatorLayout = CalendarDefaults.IndicatorLayout.Row,
     isContentClickable: Boolean = true,
     onPreviousMonthClick: () -> Unit = {},
-    onNextMonthClick: () -> Unit = {}
+    onNextMonthClick: () -> Unit = {},
+    monthNameFormat: TextStyle = TextStyle.FULL
 )
 ```
 
@@ -124,6 +125,7 @@ uses the locale’s first day.
 - `isContentClickable`: Determines whether the calendar days are clickable. Defaults to `true`.
 - `onPreviousMonthClick`: Callback invoked when navigating to the previous month.
 - `onNextMonthClick`: Callback invoked when navigating to the next month.
+- `monthNameFormat`: The `java.time.format.TextStyle` used to determine the month name display format. Defaults to `TextStyle.FULL`.
 
 ### ComposeCalendar
 
@@ -145,7 +147,8 @@ fun <T> ComposeCalendar(
     indicatorLayout: CalendarDefaults.IndicatorLayout = CalendarDefaults.IndicatorLayout.Row,
     isContentClickable: Boolean = true,
     onPreviousMonthClick: () -> Unit = {},
-    onNextMonthClick: () -> Unit = {}
+    onNextMonthClick: () -> Unit = {},
+    monthNameFormat: TextStyle = TextStyle.FULL
 )
 ```
 
@@ -174,6 +177,7 @@ uses the locale’s first day.
 - `isContentClickable`: Determines whether the calendar days are clickable. Defaults to `true`.
 - `onPreviousMonthClick`: Callback invoked when navigating to the previous month.
 - `onNextMonthClick`: Callback invoked when navigating to the next month.
+- `monthNameFormat`: The `java.time.format.TextStyle` used to determine the month name display format. Defaults to `TextStyle.FULL`.
 
 
 ### CalendarEvents

--- a/app/src/main/java/dev/alejo/composecalendar/MainActivity.kt
+++ b/app/src/main/java/dev/alejo/composecalendar/MainActivity.kt
@@ -32,6 +32,7 @@ import dev.alejo.compose_calendar.SimpleComposeCalendar
 import dev.alejo.compose_calendar.util.CalendarDefaults
 import dev.alejo.composecalendar.ui.theme.ComposeCalendarTheme
 import java.time.LocalDate
+import java.time.format.TextStyle
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -87,7 +88,8 @@ fun Calendar(modifier: Modifier = Modifier, state: CalendarState) {
             indicatorLayout = CalendarDefaults.IndicatorLayout.Column,
             isContentClickable = false,
             onPreviousMonthClick = { println("Prev") },
-            onNextMonthClick = { println("Next") }
+            onNextMonthClick = { println("Next") },
+            monthNameFormat = TextStyle.FULL_STANDALONE
         )
     }
 }

--- a/compose_calendar/src/main/java/dev/alejo/compose_calendar/ComposeCalendar.kt
+++ b/compose_calendar/src/main/java/dev/alejo/compose_calendar/ComposeCalendar.kt
@@ -22,6 +22,7 @@ import dev.alejo.compose_calendar.util.buildCalendarCache
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.format.TextStyle
 import java.time.temporal.WeekFields
 import java.util.Locale
 
@@ -45,6 +46,7 @@ import java.util.Locale
  * @param isContentClickable Flag that enables or disables clicking on individual day cells.
  * @param onPreviousMonthClick Lambda invoked when the user navigates to the previous month.
  * @param onNextMonthClick Lambda invoked when the user navigates to the next month.
+ * @param monthNameFormat [TextStyle] to determine the month name display format.
  */
 
 @Composable
@@ -60,7 +62,8 @@ fun <T> ComposeCalendar(
     indicatorLayout: CalendarDefaults.IndicatorLayout = CalendarDefaults.IndicatorLayout.Row,
     isContentClickable: Boolean = true,
     onPreviousMonthClick: () -> Unit = {},
-    onNextMonthClick: () -> Unit = {}
+    onNextMonthClick: () -> Unit = {},
+    monthNameFormat: TextStyle = TextStyle.FULL
 ) {
     val calendarCache = remember(firstDayOfWeek) {
         mutableStateOf(buildCalendarCache(firstDayOfWeek))
@@ -119,7 +122,8 @@ fun <T> ComposeCalendar(
                     onNextMonthClick()
                     currentMonth = currentMonth.plusMonths(1)
                 }
-            }
+            },
+            monthNameFormat = monthNameFormat
         )
         CalendarBody(
             events = currentMonthEvents,
@@ -153,6 +157,7 @@ fun <T> ComposeCalendar(
  * @param isContentClickable Flag that enables or disables clicking on individual day cells.
  * @param onPreviousMonthClick Lambda invoked when the user navigates to the previous month.
  * @param onNextMonthClick Lambda invoked when the user navigates to the next month.
+ * @param monthNameFormat [TextStyle] to determine the month name display format.
  */
 
 @Composable
@@ -168,7 +173,8 @@ fun SimpleComposeCalendar(
     indicatorLayout: CalendarDefaults.IndicatorLayout = CalendarDefaults.IndicatorLayout.Row,
     isContentClickable: Boolean = true,
     onPreviousMonthClick: () -> Unit = {},
-    onNextMonthClick: () -> Unit = {}
+    onNextMonthClick: () -> Unit = {},
+    monthNameFormat: TextStyle = TextStyle.FULL
 ) {
     ComposeCalendar<Unit>(
         modifier = modifier,
@@ -184,6 +190,7 @@ fun SimpleComposeCalendar(
         maxIndicators = maxIndicators,
         isContentClickable = isContentClickable,
         onPreviousMonthClick = onPreviousMonthClick,
-        onNextMonthClick = onNextMonthClick
+        onNextMonthClick = onNextMonthClick,
+        monthNameFormat = monthNameFormat
     )
 }

--- a/compose_calendar/src/main/java/dev/alejo/compose_calendar/component/CalendarHeader.kt
+++ b/compose_calendar/src/main/java/dev/alejo/compose_calendar/component/CalendarHeader.kt
@@ -39,6 +39,7 @@ import java.util.Locale
  * @param isNextButtonEnable Flag to enable or disable the button that navigates to the next month.
  * @param onPreviousMonthClick Lambda invoked when the previous month navigation button is clicked.
  * @param onNextMonthClick Lambda invoked when the next month navigation button is clicked.
+ * @param monthNameFormat [TextStyle] to determine the month name display format.
  */
 
 @Composable
@@ -49,12 +50,13 @@ fun CalendarHeader(
     isPreviousButtonEnable: Boolean,
     isNextButtonEnable: Boolean,
     onPreviousMonthClick: () -> Unit,
-    onNextMonthClick: () -> Unit
+    onNextMonthClick: () -> Unit,
+    monthNameFormat: TextStyle
 ) {
     val daysOfWeek = (0..6).map { index ->
         DayOfWeek.of(((firstDayOfWeek.value - 1 + index) % 7) + 1)
     }
-    val monthName = currentMonth.month.getDisplayName(TextStyle.FULL, Locale.getDefault())
+    val monthName = currentMonth.month.getDisplayName(monthNameFormat, Locale.getDefault())
     val year = currentMonth.year
 
     MonthAndNavigation(


### PR DESCRIPTION
**Summary**
Added `monthNameFormat` to `ComposeCalendar` and `CalendarHeader` to allow custom month name formatting.

**Changes**

- Introduced `monthNameFormat` parameter to core calendar components.
- Updated `README.md` with documentation for the new property.
- Updated the sample app to demonstrate custom formatting.